### PR TITLE
take over dependabots axios bump to package.json

### DIFF
--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "axios": "^1.3.4",
+        "axios": "^1.6.2",
         "jest": "^29.5.0",
         "keycloak-connect": "^21.0.1",
         "qs": "^6.11.1",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -11,7 +11,7 @@
   "author": "tegos Group | Hendrik Willeke",
   "license": "UNLICENSED",
   "dependencies": {
-    "axios": "^1.3.4",
+    "axios": "^1.6.2",
     "jest": "^29.5.0",
     "keycloak-connect": "^21.0.1",
     "qs": "^6.11.1",


### PR DESCRIPTION
Dependabot updated the module axios in https://github.com/Entwicklung-AvaL-Standard/oauth2-samples/pull/8, but only for the package-lock.json, because this automatically happened with updating the package chromedriver in this same PR https://github.com/Entwicklung-AvaL-Standard/oauth2-samples/pull/8.
In my opinion, the package.json should also reflect this change.